### PR TITLE
Fix typo: Change "ServerScriptStorage" to "ServerScriptService"

### DIFF
--- a/content/en-us/chat/examples/group-chat-tags.md
+++ b/content/en-us/chat/examples/group-chat-tags.md
@@ -5,7 +5,7 @@ description: Example of how to assign chat tags to players based on their member
 
 This example demonstrates how to assign chat tags to players based on their membership of a group. Chat tags are a way to visually identify a player in the chat window and useful for indicating a player's role, status, or group membership.
 
-First, create a script in ServerScriptStorage, and add the following code to it:
+First, create a script in ServerScriptService, and add the following code to it:
 
 ```lua title="Server"
 local Players = game:GetService("Players")


### PR DESCRIPTION
## Changes

This pull request corrects a typo in the code where "ServerScriptStorage" was mistakenly used instead of "ServerScriptService".

[source](https://create.roblox.com/docs/chat/examples/group-chat-tags)

## Checks

By submitting your pull request for review, you agree to the following:

- [X] This contribution was created in whole or in part by me, and I have the right to submit it under the terms of this repository's open source licenses.
- [X] I understand and agree that this contribution and a record of it are public, maintained indefinitely, and may be redistributed under the terms of this repository's open source licenses.
- [X] To the best of my knowledge, all proposed changes are accurate.
